### PR TITLE
moved box sizing into named rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ Add a preload to your compiler options:
 
 The inspector will find the running Fulcro application, and be ready to inspect it!
 
+## Contributing
+
+Development is done against apps in dev cards, so run figwheel
+via:
+
+```
+lein run -m clojure.main script/figwheel.clj
+```
+
+This will start a build for tests and devcards. Open
+[http://localhost:3389](http://localhost:3389) for the
+cards, and
+[http://localhost:3389/test.html](http://localhost:3389/test.html) for the
+tests.
+
+You can run the tests (once) from the command line with `make tests`
+
 ## Authors
 
 Fulcro Inspect was written and contributed by Wilker Lucio.

--- a/src/fulcro/inspect/core.cljs
+++ b/src/fulcro/inspect/core.cljs
@@ -45,14 +45,15 @@
   (query [_] [::inspectors {::current-app (om/get-query inspector/Inspector)}])
 
   static css/CSS
-  (local-rules [_] [[:* {:box-sizing "border-box"}]
-                    [:.container {:display        "flex"
+  (local-rules [_] [[:.container {:display        "flex"
                                   :flex-direction "column"
+                                  :box-sizing     "border-box"
                                   :width          "100%"
                                   :height         "100%"
                                   :overflow       "hidden"}]
                     [:.selector {:font-family ui/label-font-family
                                  :font-size   ui/label-font-size
+                                 :box-sizing  "border-box"
                                  :display     "flex"
                                  :align-items "center"
                                  :background  "#f3f3f3"
@@ -62,6 +63,7 @@
                                  :user-select "none"}]
                     [:.label {:margin-right "10px"}]
                     [:.no-app {:display         "flex"
+                               :box-sizing      "border-box"
                                :background      "#f3f3f3"
                                :font-family     ui/label-font-family
                                :font-size       "23px"


### PR DESCRIPTION
This fixes the bleeding of rules into the parent. As far as I can tell it does not break the inspector layout, but you might see something I missed.