### PR TITLE
Tweaks for big table rendering optimizations

### DIFF
--- a/src/ui/fulcro/inspect/ui/data_viewer.cljs
+++ b/src/ui/fulcro/inspect/ui/data_viewer.cljs
@@ -125,14 +125,14 @@
 (defn render-set [input content]
   (render-sequential (assoc input :open-close ["#{" "}"]) content))
 
-(defn is-normalized-edge? [v]
+(defn normalized-edge? [v]
   (or (util/ident? v)
       (and (vector? v)
            (util/ident? (first v)))))
 
-(defn scalar-or-normalized-edge? [v] (not (or (map? v)
-                                              (is-normalized-edge? v))))
-
+(defn scalar-or-normalized-edge? [v] (or
+                                       (normalized-edge? v)
+                                       (not (or (map? v) (vector? v) (set? v)))))
 
 (defn leaf? [content]
   (and (map? content) (every? #(scalar-or-normalized-edge? %) (vals content))))

--- a/src/ui/fulcro/inspect/ui/data_viewer.cljs
+++ b/src/ui/fulcro/inspect/ui/data_viewer.cljs
@@ -145,16 +145,16 @@
                                    old-content  :content
                                    :as          old-props} (fp/props this)]
                               (tufte/profile {}
-                                (tufte/p :scu
-                                  (not
-                                    (and
-                                      (leaf? content)
-                                      (= search old-search)
-                                      (= (old-expanded path) (expanded path))
-                                      (= old-content content)))))))}
+                                             (tufte/p :map-scu
+                                                      (not
+                                                        (and
+                                                          (leaf? content)
+                                                          (= search old-search)
+                                                          (= (old-expanded path) (expanded path))
+                                                          (= old-content content)))))))}
   (tufte/profile {}
-    (tufte/p :map
-      (dom/div #js {:className (:data-row css)}
+                 (tufte/p :map-body
+                          (dom/div #js {:className (:data-row css)}
         (if (and (not static?)
               (or (not elide-one?)
                 (> 1 (count content))))
@@ -183,9 +183,9 @@
           (expanded path)
           (if (every? keyable? (keys content))
             (dom/div #js {:className (:map-container css)}
-              (tufte/p :sorted-1
-                (into []
-                  (mapcat (fn [[k v]]
+                     (tufte/p :map-mapcat
+                              (into []
+                                    (mapcat (fn [[k v]]
                             (if (expanded (conj path k))
                               [(dom/div #js {:key (str k "-key")}
                                  (dom/div #js {:className (:list-item-index css)}
@@ -205,7 +205,7 @@
                                        (render-data input k))
                                      (render-data input k))))
                                (dom/div #js {:key (str k "-value")} (render-data (update input :path conj k) v))])))
-                  (tufte/p :sort (sort-by (comp str first) content)))))
+                                    (tufte/p :map-sort (sort-by (comp str first) content)))))
 
             (dom/div #js {:className (:list-container css)}
               (render-ordered-list input content)))
@@ -390,8 +390,8 @@
 
   (dom/div :.container
     (tufte/profile {}
-      (tufte/p :top-level-render-data
-        (render-data {:expanded    expanded
+                   (tufte/p :data-viewer
+                            (render-data {:expanded expanded
                       :static?     static?
                       :search      search
                       :elide-one?  elide-one?

--- a/src/ui/fulcro/inspect/ui/data_viewer.cljs
+++ b/src/ui/fulcro/inspect/ui/data_viewer.cljs
@@ -9,7 +9,8 @@
     [fulcro.inspect.helpers.clipboard :as clip]
     [fulcro.inspect.ui.core :as ui]
     [fulcro.inspect.ui.effects :as effects]
-    [fulcro.inspect.ui.events :as events]))
+    [fulcro.inspect.ui.events :as events]
+    [fulcro.util :as util]))
 
 (declare DataViewer)
 
@@ -124,10 +125,17 @@
 (defn render-set [input content]
   (render-sequential (assoc input :open-close ["#{" "}"]) content))
 
-(defn scalar? [v] (not (or (map? v) (vector? v))))
+(defn is-normalized-edge? [v]
+  (or (util/ident? v)
+      (and (vector? v)
+           (util/ident? (first v)))))
+
+(defn scalar-or-normalized-edge? [v] (not (or (map? v)
+                                              (is-normalized-edge? v))))
+
 
 (defn leaf? [content]
-  (and (map? content) (every? #(scalar? %) (vals content))))
+  (and (map? content) (every? #(scalar-or-normalized-edge? %) (vals content))))
 
 (fp/defsc Map [this {:keys [css search expanded path toggle path-action elide-one? static? content] :as input}]
   {:shouldComponentUpdate (fn [new-props _]


### PR DESCRIPTION
I've added the rough check for `normalized-edge` which is utilised in the 

 **Checkpoints for calling the `... stats()`** 

1. After first render 
2. After opening up the `id` tree
3. After opening one of the children of `id`

The results are pretty much the same as per the checkpoints


- With `scalar?` only check in `leaf?`

![Screenshot 2019-10-21 at 7 55 08 PM (2)](https://user-images.githubusercontent.com/12799326/67215289-daf2b680-f43e-11e9-81ba-05de1c55bb68.png)

- With `scalar-or-normalized-edge?`  check

![Screenshot 2019-10-21 at 7 56 47 PM (2)](https://user-images.githubusercontent.com/12799326/67215291-daf2b680-f43e-11e9-9ce9-c8d0ff9e1168.png)
