### PR TITLE
release chrome: use npx

### DIFF
--- a/script/release-chrome
+++ b/script/release-chrome
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-shadow-cljs release chrome chrome-devtool
+npx shadow-cljs release chrome chrome-devtool
 mkdir -p releases
 rm -rf releases/chrome
 cp -rf shells/chrome releases


### PR DESCRIPTION
so that you can run the script without adding node_modules/.bin to the PATH