### PR TITLE
adding print and read-string handlers for transit bigdec and fulcro tempids

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
 tests:
 	npm install
 	lein doo chrome automated-tests once
+electron-dev:
+	(cd shells/electron; electron .)

--- a/src/client/fulcro/inspect/helpers.cljs
+++ b/src/client/fulcro/inspect/helpers.cljs
@@ -239,7 +239,7 @@
     (assoc-in [:params :fulcro.inspect.core/client-connection-id] (ref-client-connection-id @state ref))
     (assoc-in [:params :fulcro.inspect.core/app-uuid] (ref-app-uuid ref))))
 
-(defn custom-pr-str [x]
+(defn pr-str-with-reader [x]
   (cond
     (transit/bigdec? x)
     #_=> (str "#transit/bigdec " \" (.-rep x) \")
@@ -250,10 +250,13 @@
 (extend-protocol IPrintWithWriter
   transit.types/TaggedValue
   (-pr-writer [x writer _]
-    (write-all writer (custom-pr-str x))))
+    (write-all writer (pr-str-with-reader x)))
+  tempid/TempId
+  (-pr-writer [x writer _]
+    (write-all writer (pr-str-with-reader x))))
 
 (defn pprint-default-handler [x]
-  (-write *out* (custom-pr-str x)))
+  (-write *out* (pr-str-with-reader x)))
 
 (-add-method cljs.pprint/simple-dispatch :default pprint-default-handler)
 


### PR DESCRIPTION
adding print and read-string handlers for transit bigdec and fulcro tempid

not sure this is the right place / project, but this fixes the query tab so it can run queries that contains these two custom types