### PR TITLE
Correct ns of install-ws

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To use the electron inspect make sure you add this preload to your preloads:
            :preloads        [com.fulcrologic.fulcro.inspect.websocket-preload]}
 ```
 
-or call the function `com.fulcrologic.fulcro.inspect.inspect-client/install-ws` somewhere in your 
+or call the function `com.fulcrologic.fulcro.inspect.inspect-ws/install-ws` somewhere in your 
 development startup.
 
 ### Choosing the Websocket Port


### PR DESCRIPTION
In fact it is here https://github.com/fulcrologic/fulcro/blob/1d5f260a0c861d7156d00638a6ae3ee315d9de7a/src/main/com/fulcrologic/fulcro/inspect/inspect_ws.cljs#L70, not anywhere in https://github.com/fulcrologic/fulcro/blob/develop/src/main/com/fulcrologic/fulcro/inspect/inspect_client.cljc