### PR TITLE
Fix element picker for React 17

### DIFF
--- a/src/client/fulcro/inspect/ui/element_picker.cljs
+++ b/src/client/fulcro/inspect/ui/element_picker.cljs
@@ -65,7 +65,9 @@
 
 (defn react-raw-instance [node]
   (if-let [instance-key (->> (gobj/getKeys node)
-                             (filter #(str/starts-with? % "__reactInternalInstance$"))
+                             (filter #(or (str/starts-with? % "__reactInternalInstance$") ; react < 17
+                                          (str/starts-with? % "__reactFiber$")))          ; react >= 17
+                             (sort-by #(if (str/starts-with? % "__reactInternalInstance$") 0 1))
                              (first))]
     (gobj/get node instance-key)))
 


### PR DESCRIPTION
Nodes seem not to have `__reactInternalInstance$...` anymore but they do have `__reactFiber$...` (and `__reactProps$...`).

I have added `sort-by` so that we prefer the old prope just in case...