### PR TITLE
Deref atom before checking internal map

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,14 @@ The setup is relatively easy:
 (ido (it/add-fulcro-inspect! app))
 ```
 
-The `ido` macro elides its body in release builds, and otherwise works just like `do`. Closure dead code elimination should remove all other traces of inspect from your release builds (aside from perhaps a few kb of stray bits).
+The `ido` macro elides its body in release builds, and otherwise works just like `do`. Closure dead code elimination
+should remove all other traces of inspect from your release builds (aside from perhaps a few kb of stray bits). If you
+need the body in a release build, set the closure defines in your shadow-cljs.edn to:
 
+```clojure
+{:closure-defines  {com.fulcrologic.fulcro.inspect.inspect-client/INSPECT true
+                    com.fulcrologic.devtools.common.target/INSPECT true}}
+```
 
 # FIXME
 

--- a/src/lib/fulcro/inspect/tool.cljc
+++ b/src/lib/fulcro/inspect/tool.cljc
@@ -18,7 +18,7 @@
   [app]
   (ilet [id (app-uuid app)
          state* (state-atom app)]
-    (when-not (contains? apps* id)
+    (when-not (contains? @apps* id)
       (let [c     (volatile! nil)
             tconn (ct/connect! {:target-id       id
                                 :tool-type       :fulcro/inspect


### PR DESCRIPTION
Fixes bug where when-not check was always true because containment was being checked in the atom rather than the internal map.

Also updates docs to clarify how to include into a release build