### PR TITLE
Add an icon to the devtools tab

### DIFF
--- a/shells/chrome/devtools-init.js
+++ b/shells/chrome/devtools-init.js
@@ -1,5 +1,5 @@
 chrome.devtools.panels.create("Fulcro Inspect",
-  "",
+  "icon-48.png",
   "inspect-panel.html",
   function (panel) {
     console.log("panel initialized", panel);


### PR DESCRIPTION
In the DevTools of Microsoft Edge the tab of an extension shows an icon when the tab is not selected and the icon + name when the tab is selected. Therefore, Fulcro Inspect is currently a black hole in the tab bar when it is not active. 

This hole corresponds to the hole (1) in devtools-init.js:

```js
chrome.devtools.panels.create("Fulcro Inspect",
  "", <1>
  "inspect-panel.html",
  function (panel) {
    console.log("panel initialized", panel);
  });
```

This PR fills the hole with the Fulcro logo.