### PR TITLE
If shadow-cljs does not finish successfully exit release-chrome

### DIFF
--- a/script/release-chrome
+++ b/script/release-chrome
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 npx shadow-cljs release chrome-content-script chrome-background chrome-devtool
+if [[ $? -ne 0 ]] ; then
+    exit 1
+fi
 mkdir -p releases
 rm -rf releases/chrome
 cp -rf shells/chrome releases


### PR DESCRIPTION
shadow-cljs might fail. For example, if the JS dependencies are not satisfied. In this case the execution of release-chrome must stop.